### PR TITLE
Add HTML minification and content hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/*
 
 node_modules
 package-lock.json
+rev-manifest*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea
+dist/*
+!dist/.gitkeep
 
 node_modules
 package-lock.json

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,6 +32,7 @@ gulp.task('watch', () => {
     gulp.watch(htmlFiles, ['html']);
     gulp.watch(scssFiles, ['sass']);
     gulp.watch(jsFiles, ['js']);
+    gulp.watch(otherFiles, ['copy']);
 });
 
 gulp.task('js', () => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,27 +1,46 @@
 const gulp = require('gulp');
 const sass = require('gulp-sass');
 const csso = require('gulp-csso');
+const htmlmin = require('gulp-htmlmin');
 const autoprefixer = require('gulp-autoprefixer');
 const uglify = require('gulp-uglify');
 
 const targetDir = 'dist';
+const htmlFiles = 'src/**/*.html';
+const scssFiles = 'src/scss/**/*.scss';
+const jsFiles = 'src/js/**/*.js';
 
-gulp.task('default', ['sass', 'js']);
+gulp.task('default', ['html', 'sass', 'js']);
 
 gulp.task('sass', () => {
-    return gulp.src('src/scss/**/*.scss')
+    return gulp.src(scssFiles)
         .pipe(sass().on('error', sass.logError))
         .pipe(autoprefixer())
         .pipe(csso())
-        .pipe(gulp.dest(targetDir))
+        .pipe(gulp.dest(`${targetDir}/css`))
 });
 
-gulp.task('sass:watch', () => {
-   gulp.watch('src/scss/**/*.scss', ['sass']);
+gulp.task('watch', () => {
+    gulp.watch(htmlFiles, ['html']);
+    gulp.watch(scssFiles, ['sass']);
+    gulp.watch(jsFiles, ['js']);
 });
 
 gulp.task('js', () => {
-    return gulp.src('src/js/**/*.js')
+    return gulp.src(jsFiles)
         .pipe(uglify())
+        .pipe(gulp.dest(`${targetDir}/js`));
+});
+
+gulp.task('html', () => {
+    return gulp.src(htmlFiles)
+        .pipe(htmlmin({
+            collapseBooleanAttributes: true,
+            collapseWhitespace: true,
+            conservativeCollapse: true,
+            decodeEntities: true,
+            minifyCSS: true,
+            minifyJS: true,
+        }))
         .pipe(gulp.dest(targetDir));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,8 +12,9 @@ const targetDir = 'dist';
 const htmlFiles = 'src/**/*.html';
 const scssFiles = 'src/scss/**/*.scss';
 const jsFiles = 'src/js/**/*.js';
+const otherFiles = ['src/**/*'].concat([htmlFiles, scssFiles, jsFiles].map((pattern) => `!${pattern}`));
 
-gulp.task('default', ['html']);
+gulp.task('default', ['html', 'copy']);
 
 gulp.task('sass', () => {
     return gulp.src(scssFiles)
@@ -57,6 +58,11 @@ gulp.task('html', ['sass', 'js'], () => {
         .pipe(revReplace({ manifest: gulp.src('./rev-manifest-sass.json') }))
         .pipe(gulp.dest(targetDir))
     ;
+});
+
+gulp.task('copy', () => {
+    return gulp.src(otherFiles)
+        .pipe(gulp.dest(targetDir));
 });
 
 gulp.task('clean', () => {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "devDependencies": {
+    "del": "^3.0.0",
     "express": "^4.15.4",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^4.0.0",
     "gulp-csso": "^3.0.0",
     "gulp-htmlmin": "^3.0.0",
+    "gulp-rev": "^8.0.0",
+    "gulp-rev-replace": "^0.4.3",
     "gulp-sass": "^3.1.0",
     "gulp-uglify": "^3.0.0",
     "normalize-scss": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^4.0.0",
     "gulp-csso": "^3.0.0",
+    "gulp-htmlmin": "^3.0.0",
     "gulp-sass": "^3.1.0",
     "gulp-uglify": "^3.0.0",
     "normalize-scss": "^7.0.0"

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const app = express();
 
-app.use(express.static('.'));
+app.use(express.static('dist'));
 
 app.listen(80, () => {
     console.log('Listening on :80!');

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width">
         <title></title>
-        <link rel="stylesheet" href="dist/style.css">
+        <link rel="stylesheet" href="css/style.css">
     </head>
     <body>
         <p>Hello world!</p>


### PR DESCRIPTION
This PR introduces the following changes:

- Move `index.html` to `src/`. This establishes a nice mapping between `src/` and `dist/` directory trees, and now the `dist/` folder contains a standalone build ready for upload.
- Add HTML minification.
- Add content hashes which help solve problems with caching.
- Introduce `clean` task which removes all contents of the `dist/` folder and `rev-manifest` files, which are generated in the build process.